### PR TITLE
Marshalling/refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,11 @@ sudo: false
 language: ruby
 rvm:
   - 2.5.0
-before_install: gem install bundler -v 1.16.1
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+  - gem install bundler -v 1.16.1
 script: bundle exec rspec
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,15 @@ GEM
   specs:
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
+    coderay (1.1.2)
     diff-lcs (1.3)
     docile (1.3.0)
     graphql (1.8.0.pre11)
     json (2.1.0)
+    method_source (0.9.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rake (10.5.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -40,6 +45,7 @@ DEPENDENCIES
   bundler (~> 1.16)
   codeclimate-test-reporter
   graphql-cache!
+  pry
   rake (~> 10.0)
   rspec (~> 3.0)
   simplecov

--- a/graphql-cache.gemspec
+++ b/graphql-cache.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "codeclimate-test-reporter"
+  s.add_development_dependency "pry"
 
   s.add_dependency 'graphql', '~> 1.8.0.pre10'
 end

--- a/lib/graphql/cache/builder.rb
+++ b/lib/graphql/cache/builder.rb
@@ -1,0 +1,95 @@
+module GraphQL
+  module Cache
+    class Builder
+      attr_accessor :raw, :method, :config
+
+      def self.[](raw)
+        build_method = namify(raw.class.name)
+        new(raw, build_method)
+      end
+
+      def self.namify(str)
+        str.split('::').last.downcase
+      end
+
+      def initialize(raw, method)
+        self.raw    = raw
+        self.method = method
+      end
+
+      def build(config)
+        self.config = config
+
+        return build_array    if method == 'array'
+        return build_relation if method == 'collectionproxy'
+        build_object
+      end
+
+      def deconstruct
+        case self.class.namify(raw.class.name)
+        when 'array'
+          deconstruct_array(raw)
+        when 'relationconnection'
+          raw.nodes
+        else
+          deconstruct_object(raw)
+        end
+      end
+
+      def deconstruct_object(raw)
+        if raw.respond_to?(:object)
+          raw.object
+        else
+          raw
+        end
+      end
+
+      def deconstruct_array(raw)
+        return [] if raw.empty?
+
+        if raw.first.class.ancestors.include? GraphQL::Schema::Object
+          raw.map(&:object)
+        else
+          raw
+        end
+      end
+
+      def build_relation
+        GraphQL::Relay::RelationConnection.new(
+          raw,
+          config[:field_args],
+          field:   config[:query_context].field,
+          parent:  config[:parent_object].object,
+          context: config[:query_context]
+        )
+      end
+
+      def build_array
+        gql_def = config[:field_definition].type.unwrap.graphql_definition
+
+        raw.map do |item|
+          if gql_def.kind.name == 'OBJECT'
+            config[:field_definition].type.unwrap.graphql_definition.metadata[:type_class].new(
+              item,
+              config[:query_context]
+            )
+          else
+            item
+          end
+        end
+      end
+
+      def build_object
+        klass = config[:field_definition].type.unwrap.graphql_definition.metadata[:type_class]
+        if klass
+          klass.new(
+            raw,
+            config[:query_context]
+          )
+        else
+          raw
+        end
+      end
+    end
+  end
+end

--- a/lib/graphql/cache/marshal.rb
+++ b/lib/graphql/cache/marshal.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'graphql/cache/builder'
+
+module GraphQL
+  module Cache
+    class Marshal
+      attr_accessor :key
+
+      def self.[](key)
+        new(key)
+      end
+
+      def initialize(key)
+        self.key = key.to_s
+      end
+
+      def read(config, &block)
+        cached = cache.read(key)
+
+        if cached.nil?
+          logger.debug "Cache miss: (#{key})"
+          write config, &block
+        else
+          logger.debug "Cache hit: (#{key})"
+          build cached, config
+        end
+      end
+
+      def write(config, &block)
+        resolved = block.call
+        expiry = config[:expiry] || GraphQL::Cache.expiry
+
+        document = Builder[resolved].deconstruct
+
+        cache.write(key, document, expires_in: expiry)
+        resolved
+      end
+
+
+      def build(cached, config)
+        Builder[cached].build(config)
+      end
+
+      def cache
+        GraphQL::Cache.cache
+      end
+
+      def logger
+        GraphQL::Cache.logger
+      end
+    end
+  end
+end

--- a/spec/graphql/cache/builder_spec.rb
+++ b/spec/graphql/cache/builder_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+
+module GraphQL
+  module Cache
+    RSpec.describe Builder do
+      let(:raw) { nil }
+      let(:method) { nil }
+
+      subject { described_class.new(raw, method) }
+
+      describe 'self#namify' do
+        subject { described_class.namify(str) }
+
+        context 'when string is a module name' do
+          let(:str) { 'GraphQL::Relay::RelationConnection' }
+
+          it { should eq 'relationconnection' }
+        end
+
+        context 'when string has capitols' do
+          let(:str) { 'UPCASE' }
+
+          it { should eq 'upcase' }
+        end
+      end
+
+      describe '#deconstruct' do
+        context 'when raw value is an array' do
+          let(:raw) do
+            [1, 2]
+          end
+
+          it 'should return the raw array' do
+            expect(subject.deconstruct).to eq [1, 2]
+          end
+
+          context 'of custom types' do
+            let(:raw) do
+              [
+                TestType.new(1, config[:query_context]),
+                TestType.new(2, config[:query_context])
+              ]
+            end
+
+            it 'should return array of inner objects' do
+              expect(subject.deconstruct).to eq [1, 2]
+            end
+          end
+
+        end
+
+        context 'when raw value is a GraphQL relation' do
+          let(:raw) do
+            GraphQL::Relay::RelationConnection.new(
+              [1, 2],
+              config[:query_context]
+            )
+          end
+
+          it 'should return inner "nodes"' do
+            expect(subject.deconstruct).to eq [1, 2]
+          end
+        end
+
+        context 'when raw value is an arbitrary object' do
+          let(:obj) { 'foo' }
+          let(:raw) { obj }
+
+          it 'should return the object' do
+            expect(subject.deconstruct).to eq obj
+          end
+
+          context 'that responds to "object"' do
+            let(:raw) { TestType.new(2, config[:query_context]) }
+
+            it 'should return inner object' do
+              expect(subject.deconstruct).to eq 2
+            end
+          end
+        end
+      end
+
+      describe '#build' do
+        subject { described_class.new(raw, method) }
+
+        context 'when method is "array"' do
+          let(:method) { 'array' }
+          let(:raw) do
+            [1, 2]
+          end
+
+          context 'when field is a scalar' do
+            config(field_definition: TestSchema.types['Test'].fields['ints'])
+
+            it 'should return an array of scalars' do
+              expect(subject.build config).to eq [1, 2]
+            end
+          end
+
+          context 'when field is an object' do
+            config(field_definition: TestSchema.types['Test'].fields['subObjects'])
+
+            it 'should return an array of object types' do
+              subject.build(config).each do |item|
+                expect(item.class).to eq SubObjectType
+              end
+            end
+          end
+        end
+
+        context 'when method is "collectionproxy"' do
+          let(:query_context) { Hash.new }
+          let(:method) { 'collectionproxy' }
+          let(:raw) do
+            [1, 2]
+          end
+
+          before do
+            allow(query_context).to receive(:field)
+            allow(query_context).to receive(:schema).and_return(TestSchema)
+            config[:query_context] = query_context
+            config[:parent_object] = TestType.new(nil,{})
+          end
+
+          it 'should build a relation collection' do
+            expect(subject.build config).to be_a GraphQL::Relay::RelationConnection
+          end
+
+          it 'should build a collection with raw value nodes' do
+            expect(subject.build(config).nodes).to eq [1, 2]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,14 @@
+require 'bundler/setup'
+require 'pry'
+
 require 'codeclimate-test-reporter'
 require 'simplecov'
 SimpleCov.start
 
-require "bundler/setup"
-require "graphql/cache"
+require 'graphql/cache'
+
+# Load support files
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -15,4 +20,12 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.before(:suite) do
+    GraphQL::Cache.cache  = TestCache.new
+    GraphQL::Cache.logger = TestLogger.new
+  end
+
+  config.include TestMacros
+  config.extend  TestMacros::ClassMethods
 end

--- a/spec/support/test_cache.rb
+++ b/spec/support/test_cache.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class TestCache
+  def write(key, doc, opts={})
+    cache[key] = doc
+  end
+
+  def read(key)
+    cache[key]
+  end
+
+  def cache
+    @cache ||= {}
+  end
+end

--- a/spec/support/test_logger.rb
+++ b/spec/support/test_logger.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class TestLogger
+  %i(
+    debug
+    info
+    warn
+    error
+    fatal
+    unknown
+  ).each do |lvl|
+    define_method lvl do |msg|
+      # msg
+    end
+  end
+end

--- a/spec/support/test_macros.rb
+++ b/spec/support/test_macros.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module TestMacros
+  def cache
+    GraphQL::Cache.cache
+  end
+
+  module ClassMethods
+    def self.extended(mod)
+      mod.class_eval do
+        config
+      end
+    end
+
+    def document(&block)
+      let(:document, &block)
+    end
+
+    def key(&block)
+      let(:key, &block)
+    end
+
+    def config(opts={})
+      let(:config) do
+        {
+          cache:            opts[:cache] || (opts[:cache].nil? ? true : false),
+          parent_type:      opts[:parent_type] || TestSchema.types['Test'],
+          parent_object:    opts[:parent_object],
+          field_definition: opts[:field_definition] || TestSchema.types['Test'].fields['anId'],
+          field_args:       opts[:field_args],
+          query_context:    opts[:query_context] || {},
+          object:           opts[:object]
+        }
+      end
+    end
+  end
+end

--- a/spec/support/test_schema.rb
+++ b/spec/support/test_schema.rb
@@ -1,0 +1,39 @@
+class SubObjectType < GraphQL::Schema::Object
+  field :an_id,     ID,      null: false
+  field :a_string,  String,  null: false
+  field :a_boolean, Boolean, null: false
+  field :an_int,    Int,     null: false
+  field :a_float,   Float,   null: false
+
+  def an_id;    123;   end
+  def a_string; 'foo'; end
+  def a_boolean; true; end
+  def an_int;    73;   end
+  def a_float;   3.14; end
+end
+
+class TestType < GraphQL::Schema::Object
+  field_class GraphQL::Cache::Field
+
+  field :an_id,       ID,              null: false
+  field :a_string,    String,          null: false
+  field :a_boolean,   Boolean,         null: false
+  field :an_int,      Int,             null: false
+  field :a_float,     Float,           null: false
+  field :sub_object,  SubObjectType,   null: false
+
+  field :ints,        [Int],           null: false
+  field :sub_objects, [SubObjectType], null: false
+
+  def an_id;       123;   end
+  def a_string;    'foo'; end
+  def a_boolean;   true; end
+  def an_int;      73;   end
+  def a_float;     3.14; end
+  def ints;        [1, 2]; end
+  def sub_objects; [1, 2]; end
+end
+
+class TestSchema < GraphQL::Schema
+  query TestType
+end


### PR DESCRIPTION
Problem
-------
The original `marshal_to_cache` and `marshal_from_cache` methods were down and dirty to get the first-pass of caching done at StackShare.  The code has several bugs and is difficult to test.

Solution
--------
This change refactors the `GraphQL::Cache.fetch` method so that it follows a more logical abstraction along with refactoring the cache marshaling code for testing coverage and maintainability.

Resolves #4 
Resolves #9 
Resolves #10 