### PR TITLE
Add support for field level expiry

### DIFF
--- a/lib/graphql/cache.rb
+++ b/lib/graphql/cache.rb
@@ -32,7 +32,7 @@ module GraphQL
     end
 
     def self.fetch(key, config: {}, &block)
-      return block.call unless config[:cache]
+      return block.call unless config[:metadata][:cache]
 
       Marshal[key].read(config, &block)
     end

--- a/lib/graphql/cache/field.rb
+++ b/lib/graphql/cache/field.rb
@@ -7,20 +7,20 @@ module GraphQL
       def initialize(
         *args,
         cache: false,
-        expiry: nil,
         **kwargs,
         &block
       )
-        @cache_config = {
-          cache: cache,
-          expiry: expiry
-        }
+        @cache_config = if cache.is_a? Hash
+                          cache
+                        else
+                          { cache: cache }
+                        end
         super(*args, **kwargs, &block)
       end
 
       def to_graphql
         field_defn = super # Returns a GraphQL::Field
-        field_defn.metadata[:cache_config] = @cache_config
+        field_defn.metadata[:cache] = @cache_config
         field_defn
       end
     end

--- a/lib/graphql/cache/marshal.rb
+++ b/lib/graphql/cache/marshal.rb
@@ -4,6 +4,7 @@ require 'graphql/cache/builder'
 
 module GraphQL
   module Cache
+    # Used to marshal data to/from cache on cache hits/misses
     class Marshal
       attr_accessor :key
 
@@ -27,16 +28,15 @@ module GraphQL
         end
       end
 
-      def write(config, &block)
-        resolved = block.call
-        expiry = config[:expiry] || GraphQL::Cache.expiry
+      def write(config)
+        resolved = yield
+        expiry = config[:metadata][:expiry] || GraphQL::Cache.expiry
 
         document = Builder[resolved].deconstruct
 
         cache.write(key, document, expires_in: expiry)
         resolved
       end
-
 
       def build(cached, config)
         Builder[cached].build(config)

--- a/lib/graphql/cache/middleware.rb
+++ b/lib/graphql/cache/middleware.rb
@@ -2,15 +2,20 @@
 
 module GraphQL
   module Cache
+    # graphql-ruby middleware to wrap resolvers for caching
     class Middleware
       attr_accessor :parent_type, :parent_object, :object, :cache,
-        :field_definition, :field_args, :query_context,
+                    :field_definition, :field_args, :query_context
 
-        def self.call(*args, &block)
-          new(*args).call(&block)
+      def self.call(*args, &block)
+        new(*args).call(&block)
       end
 
-      def initialize(parent_type, parent_object, field_definition, field_args, query_context)
+      def initialize(parent_type,
+                     parent_object,
+                     field_definition,
+                     field_args,
+                     query_context)
         self.parent_type      = parent_type
         self.parent_object    = parent_object
         self.field_definition = field_definition
@@ -28,7 +33,15 @@ module GraphQL
           field_args:       field_args,
           query_context:    query_context,
           object:           object
-        }.merge(field_definition.metadata[:cache_config] || {})
+        }.merge metadata_hash
+      end
+
+      def metadata_hash
+        {
+          metadata: {
+            cache: field_definition.metadata[:cache] || {}
+          }
+        }
       end
 
       def call(&block)

--- a/spec/graphql/cache_spec.rb
+++ b/spec/graphql/cache_spec.rb
@@ -27,15 +27,20 @@ RSpec.describe GraphQL::Cache do
     describe '#fetch' do
       let(:key)   { 'key' }
       let(:value) { 'foo' }
+      let(:cache_config) do
+        {}
+      end
       let(:config) do
         {
-          cache:            true,
           parent_type:      TestSchema.types['Test'],
           parent_object:    nil,
           field_definition: TestSchema.types['Test'].fields['anId'],
           field_args:       nil,
           query_context:    nil,
-          object:           nil
+          object:           nil,
+          metadata: {
+            cache: cache_config
+          }
         }
       end
 
@@ -43,8 +48,8 @@ RSpec.describe GraphQL::Cache do
         described_class.fetch(key, config: config) { value }
       end
 
-      context 'config->cache is not set' do
-        let(:config) { Hash.new }
+      context 'metadata->cache is not set' do
+        let(:cache_config) { nil }
 
         it 'should return resolver result' do
           expect(subject).to eq 'foo'


### PR DESCRIPTION
Problem
-------
We technically have the ability to set a field-level expiration, but it doesn't conform to the API we want for v1.0.0

Solution
--------
Refactor so that instead of separate keyword params on `field` we now accept 1 keyword, `cache`.  This can be set to any value.  If it is not `nil` caching is enabled for the field.  If it is a hash, it is examined for keywords.  In this case, `expiry`.

Notes
-----
I'm not 100% happy with the way we're having to do this with the custom field class, but that's a larger discussion outside the scope of this change.

Resolves #1 