### PR TITLE
16 integration specs

### DIFF
--- a/lib/graphql/cache/middleware.rb
+++ b/lib/graphql/cache/middleware.rb
@@ -16,7 +16,7 @@ module GraphQL
         self.field_definition = field_definition
         self.field_args       = field_args
         self.query_context    = query_context
-        self.object           = parent_object.try(:object)
+        self.object           = parent_object.object if parent_object
         self.cache            = ::GraphQL::Cache.cache
       end
 
@@ -51,9 +51,13 @@ module GraphQL
       def object_key
         return nil unless object
 
-        id_from_object = object.try(:id) || object.try(:fetch, :id, nil) || object.try(:fetch, 'id', nil)
-
         "#{object.class.name}:#{id_from_object}"
+      end
+
+      def id_from_object
+        return object.id if object.respond_to? :id
+        return object.fetch(:id, nil) if object.respond_to? :fetch
+        return object.fetch('id', nil) if object.respond_to? :fetch
       end
     end
   end

--- a/spec/graphql/cache/middleware_spec.rb
+++ b/spec/graphql/cache/middleware_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module GraphQL
+  module Cache
+    RSpec.describe Middleware do
+      let(:query) do
+        %Q{
+          {
+            ints
+          }
+        }
+      end
+      let(:result) do
+        GraphQL::Query.new(TestSchema, query, {}).result
+      end
+
+      context 'when cache is cold' do
+        it 'should return value from resolver' do
+          expect(result['data']['ints']).to eq [1, 2]
+        end
+      end
+
+      context 'when cache is warm' do
+        let(:key) { '["GraphQL::Cache", nil, "ints"]' }
+        let(:document) { [3,2,1] }
+
+        before do
+          cache.write(key, document)
+        end
+
+        it 'should return value from cache' do
+          expect(result['data']['ints']).to eq [3, 2, 1]
+        end
+      end
+    end
+  end
+end

--- a/spec/support/test_schema.rb
+++ b/spec/support/test_schema.rb
@@ -22,7 +22,7 @@ class TestType < GraphQL::Schema::Object
   field :a_float,     Float,           null: false
   field :sub_object,  SubObjectType,   null: false
 
-  field :ints,        [Int],           null: false
+  field :ints,        [Int],           null: false, cache: true
   field :sub_objects, [SubObjectType], null: false
 
   def an_id;       123;   end
@@ -36,4 +36,6 @@ end
 
 class TestSchema < GraphQL::Schema
   query TestType
+
+  middleware GraphQL::Cache::Middleware
 end


### PR DESCRIPTION
Problem
-------
We don't currently have any specs covering actual execution of GraphQL queries.

Solution
--------
Added a couple of actual schema executing specs.

Notes
-----
With this spec I also found some uses of `try` which can't be assumed to be present in all environments. (I'm trying to make sure the gem is compatible with non-rails implementations).

Resolves #16 