### PR TITLE
Bump gemer and handle nodes case

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     graphql-cache (0.2.1)
       gemer (~> 0.1)
-      graphql (~> 1.8.0.pre10)
+      graphql (~> 1.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -13,7 +13,7 @@ GEM
     coderay (1.1.2)
     diff-lcs (1.3)
     docile (1.3.0)
-    gemer (0.1.1)
+    gemer (0.1.2)
     graphql (1.8.0)
     json (2.1.0)
     method_source (0.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-cache (0.2.1)
+    graphql-cache (0.2.2)
       gemer (~> 0.1)
       graphql (~> 1.8.0)
 

--- a/graphql-cache.gemspec
+++ b/graphql-cache.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov'
 
   s.add_dependency 'gemer', '~> 0.1'
-  s.add_dependency 'graphql', '~> 1.8.0.pre10'
+  s.add_dependency 'graphql', '~> 1.8.0'
 end

--- a/lib/graphql/cache/middleware.rb
+++ b/lib/graphql/cache/middleware.rb
@@ -21,8 +21,12 @@ module GraphQL
         self.field_definition = field_definition
         self.field_args       = field_args
         self.query_context    = query_context
-        self.object           = parent_object.object if parent_object
         self.cache            = ::GraphQL::Cache.cache
+
+        return unless parent_object
+
+        self.object = parent_object.nodes if parent_object.respond_to? :nodes
+        self.object = parent_object.object if parent_object.respond_to? :object
       end
 
       def cache_config

--- a/lib/graphql/cache/version.rb
+++ b/lib/graphql/cache/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module Cache
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
   end
 end


### PR DESCRIPTION
Problem
-------

  When a connection is queried it throws a `undefined method 'object' for <connection-class>`.

Cause (for defects/bugs)
------------------------

  The API for internal objects on connections changed slightly between pre10 and 1.8.0.  

Solution
--------

  We now need to use `nodes`.  I've also changed the logic a bit to ensure safe handling of object.


Resolves #19 