### PR TITLE
Add basic setup for RDoc documentation

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,6 @@
+--no-private
+--markup=markdown
+--readme=readme.md
+--title='GraphQL Ruby API Documentation'
+'lib/**/*.rb' - '*.md'
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# GraphQL Cache [![Build Status](https://travis-ci.org/Leanstack/graphql-cache.svg?branch=master)](https://travis-ci.org/Leanstack/graphql-cache) [![Test Coverage](https://api.codeclimate.com/v1/badges/c8560834b10db0618175/test_coverage)](https://codeclimate.com/github/Leanstack/graphql-cache/test_coverage) [![Maintainability](https://api.codeclimate.com/v1/badges/c8560834b10db0618175/maintainability)](https://codeclimate.com/github/Leanstack/graphql-cache/maintainability)
+# GraphQL Cache
+  [![Build Status](https://travis-ci.org/Leanstack/graphql-cache.svg?branch=master)](https://travis-ci.org/Leanstack/graphql-cache) [![Test Coverage](https://api.codeclimate.com/v1/badges/c8560834b10db0618175/test_coverage)](https://codeclimate.com/github/Leanstack/graphql-cache/test_coverage) [![Maintainability](https://api.codeclimate.com/v1/badges/c8560834b10db0618175/maintainability)](https://codeclimate.com/github/Leanstack/graphql-cache/maintainability)
 
   GraphQL Cache is a custom middleware for graphql-ruby providing field-level caching.  It is currently a work in progress and the API is subject to change prior to the release v1.0.0.
 
@@ -55,11 +56,9 @@
 
   When passing a hash in the `cache` parameter the possible options are:
 
-  | Key      | Default | Description                                                |
-  |----------|---------|------------------------------------------------------------|
-  | `expiry` | 5400    | expiration time for this field's key in seconds            |
-  | `force`  | false   | force cache misses on this field                           |
-  | `prefix` |         | cache key prefix (appended after GraphQL::Cache.namespace) |
+  - `expiry`: expiration time for this field's key in seconds (default: 5400)
+  - `force`: for cache misses on this field (default: false)
+  - `prefix`: cache key prefix (appended after GraphQL::Cache.namespace)
 
 ## Development
 

--- a/lib/graphql/cache.rb
+++ b/lib/graphql/cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gemer'
 
 require 'graphql/cache/version'
@@ -17,6 +19,14 @@ module GraphQL
       c.attr :namespace, 'GraphQL::Cache'
     end
 
+    # Fetches/writes a value for +key+ from the cache
+    #
+    # Always evaluates the block unless config[:metadata][:cache] is truthy
+    #
+    # @param key [String] the cache key to attempt to fetch
+    # @param config [Hash] a hash of middleware config values used to marshal cache data
+    # @option config [Hash] :metadata The metadata collected from the field definition
+    # @return [Object]
     def self.fetch(key, config: {}, &block)
       return block.call unless config[:metadata][:cache]
 

--- a/lib/graphql/cache/builder.rb
+++ b/lib/graphql/cache/builder.rb
@@ -8,6 +8,7 @@ module GraphQL
         new(raw, build_method)
       end
 
+      # Ruby-only means of "demodularizing" a string
       def self.namify(str)
         str.split('::').last.downcase
       end

--- a/lib/graphql/cache/middleware.rb
+++ b/lib/graphql/cache/middleware.rb
@@ -7,6 +7,7 @@ module GraphQL
       attr_accessor :parent_type, :parent_object, :object, :cache,
                     :field_definition, :field_args, :query_context
 
+      # Called by graphql-ruby during middleware processing
       def self.call(*args, &block)
         new(*args).call(&block)
       end
@@ -29,6 +30,7 @@ module GraphQL
         self.object = parent_object.object if parent_object.respond_to? :object
       end
 
+      # @private
       def cache_config
         {
           parent_type:      parent_type,
@@ -40,6 +42,7 @@ module GraphQL
         }.merge metadata_hash
       end
 
+      # @private
       def metadata_hash
         {
           metadata: {
@@ -48,6 +51,9 @@ module GraphQL
         }
       end
 
+      # The primary caching entry point
+      #
+      # @return [Object]
       def call(&block)
         GraphQL::Cache.fetch(
           cache_key,
@@ -56,6 +62,7 @@ module GraphQL
         )
       end
 
+      # @private
       def cache_key
         @cache_key ||= [
           GraphQL::Cache.namespace,
@@ -65,12 +72,14 @@ module GraphQL
         ].flatten
       end
 
+      # @private
       def object_key
         return nil unless object
 
         "#{object.class.name}:#{id_from_object}"
       end
 
+      # @private
       def id_from_object
         return object.id if object.respond_to? :id
         return object.fetch(:id, nil) if object.respond_to? :fetch


### PR DESCRIPTION
Problem
-------
Since https://www.rubydoc.info/gems/graphql-cache/ exists, we might as
well take advantage of it.

Solution
--------
I've added some high-level rdoc comments and setup yardopts and the
README to render well.